### PR TITLE
Add option to treat weekends as business days

### DIFF
--- a/lib/business_calendar.rb
+++ b/lib/business_calendar.rb
@@ -9,17 +9,17 @@ module BusinessCalendar
       if options["use_cached_calendar"]
         calendar_cache[country] ||= Calendar.new(holiday_determiner(country))
       else
-        Calendar.new(holiday_determiner(country))
+        Calendar.new(holiday_determiner(country), options)
       end
     end
 
-    def for_organization(org)
-      Calendar.new(holiday_determiner_for_organization(org))
+    def for_organization(org, options = {})
+      Calendar.new(holiday_determiner_for_organization(org), options)
     end
 
-    def for_endpoint(additions, removals, opts = {})
-      ttl = opts["ttl"] || 300
-      Calendar.new(holiday_determiner_for_endpoint(additions, removals, opts), {"ttl" => ttl})
+    def for_endpoint(additions, removals, options = {})
+      ttl = options["ttl"] || 300
+      Calendar.new(holiday_determiner_for_endpoint(additions, removals, options), options.merge({"ttl" => ttl}))
     end
 
     private

--- a/lib/business_calendar/calendar.rb
+++ b/lib/business_calendar/calendar.rb
@@ -22,7 +22,7 @@ class BusinessCalendar::Calendar
   # @param [Date]     date
   # @return [Boolean] Whether or not banking can be done on <date>.
   def is_business_day?(date)
-    return false if date.saturday? || date.sunday?
+    return false if !@options["business_weekends"] && (date.saturday? || date.sunday?)
     return false if is_holiday?(date)
     true
   end


### PR DESCRIPTION
This is intended for businesses that operate on weekends as well. 

By default weekends are *not* considered business days. Pass `{"business_weekends" => true}` in the `options` field to enable them as business days.