### PR TITLE
Restore support for 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-  - 2.3.1
-  - 1.9.3
 
-script: bundle exec rspec
+matrix:
+  include:
+    - rmv: ree
+      gemfile: gemfiles/ree.gemfile
+      script: bundle exec rspec
+    - rvm: 1.9.3
+      script: bundle exec rspec
+    - rvm: 2.3.1
+      script: bundle exec rspec
 
 env:
   global:

--- a/business_calendar.gemspec
+++ b/business_calendar.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency "holidays", "~> 1.0"
   spec.add_dependency "faraday"
@@ -28,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "timecop"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry"
 end

--- a/gemfiles/ree.gemfile
+++ b/gemfiles/ree.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'addressable', '< 2.4.0'
+gem 'json',        '< 2'
+gem 'faraday',     '< 0.10'
+gem 'hashdiff',    '0.3.0'
+gem 'pry',         '< 0.10'
+
+# Specify your gem's dependencies in business_calendar.gemspec
+gemspec :path => '../'

--- a/spec/business_calendar_spec.rb
+++ b/spec/business_calendar_spec.rb
@@ -165,7 +165,7 @@ describe BusinessCalendar do
     end
   end
 
-  context "with an API endpoint", focus: true do
+  context "with an API endpoint" do
     let(:additions) { 'http://fakeendpoint.test/additions' }
     let(:removals) { 'http://fakeendpoint.test/removals' }
 
@@ -173,13 +173,13 @@ describe BusinessCalendar do
 
     before do
       stub_request(:get, additions).to_return(
-        status: 200,
-        body: {'holidays' => ['2014-07-04', '2014-07-05']}.to_json
+        :status => 200,
+        :body => {'holidays' => ['2014-07-04', '2014-07-05']}.to_json
       )
 
       stub_request(:get, removals).to_return(
-        status: 200,
-        body: {'holidays' => ['2014-12-24', '2014-12-25']}.to_json
+        :status => 200,
+        :body => {'holidays' => ['2014-12-24', '2014-12-25']}.to_json
       )
     end
 
@@ -202,14 +202,16 @@ describe BusinessCalendar do
     end
 
     it 'caches holidays for 5 min' do
-      Timecop.freeze(Time.now)
+      start = Time.now
+
+      allow(Time).to receive(:now) { start }
 
       subject.is_business_day?('2014-07-04'.to_date)
       subject.is_business_day?('2014-07-04'.to_date)
 
       expect(a_request(:get, additions)).to have_been_made.times(1)
 
-      Timecop.freeze(Time.now + 301)
+      allow(Time).to receive(:now) { start + 301 }
 
       subject.is_business_day?('2014-07-04'.to_date)
 
@@ -217,7 +219,7 @@ describe BusinessCalendar do
     end
 
     context 'http request fails' do
-      before { stub_request(:get, additions).to_return(status: 500) }
+      before { stub_request(:get, additions).to_return(:status => 500) }
 
       it 'raises an error' do
         expect { subject.is_business_day?('2014-07-04'.to_date) }.to raise_error Faraday::ClientError

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'simplecov'
 require 'business_calendar'
 require 'date'
 require 'webmock/rspec'
-require 'timecop'
 require 'pry'
 
 # I'm not depending on ActiveSupport just for this.


### PR DESCRIPTION
We have a number of production applications still using this. It
doesn't seem worth it to break compatibility for new hash synax and
timecop.