### PR TITLE
Remove faraday-conductivity + bundler dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       script: bundle exec rspec
     - rvm: 1.9.3
       script: bundle exec rspec
+      gemfile: gemfiles/ruby_1.9.3.gemfile
     - rvm: 2.3.1
       script: bundle exec rspec
 

--- a/business_calendar.gemspec
+++ b/business_calendar.gemspec
@@ -18,11 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-
   spec.add_dependency "holidays", "~> 1.0"
   spec.add_dependency "faraday"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "webmock"

--- a/business_calendar.gemspec
+++ b/business_calendar.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "holidays", "~> 1.0"
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday-conductivity"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/gemfiles/ruby_1.9.3.gemfile
+++ b/gemfiles/ruby_1.9.3.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'json', '< 2.3.0'
+
+# Specify your gem's dependencies in business_calendar.gemspec
+gemspec :path => '../'

--- a/lib/business_calendar.rb
+++ b/lib/business_calendar.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday/conductivity'
 
 module BusinessCalendar
   CountryNotSupported = Class.new(StandardError)
@@ -51,7 +50,7 @@ module BusinessCalendar
 
     def holiday_determiner_for_endpoint(additions_endpoint, removals_endpoint, opts)
       client = Faraday.new do |conn|
-        conn.response :selective_errors
+        conn.response :raise_error
         conn.adapter :net_http
       end
 

--- a/spec/business_calendar_spec.rb
+++ b/spec/business_calendar_spec.rb
@@ -366,7 +366,7 @@ describe BusinessCalendar do
       before { stub_request(:get, additions).to_return(:status => 500) }
 
       it 'raises an error' do
-        expect { subject.is_business_day?('2014-07-04'.to_date) }.to raise_error Faraday::ClientError
+        expect { subject.is_business_day?('2014-07-04'.to_date) }.to raise_error Faraday::Error
       end
     end
 


### PR DESCRIPTION
* bundler dependency seems overly strict and probably doesn't need to be in the gemspec
* faraday-conductivity was never needed, given that we're just trying to raise errors that the Faraday raise_error middleware already raises. https://lostisland.github.io/faraday/middleware/raise-error
* updates .travis.yml to fix broken test runs