### PR TITLE
Allow list of additions and removals for holiday determiner

### DIFF
--- a/lib/business_calendar/holiday_determiner.rb
+++ b/lib/business_calendar/holiday_determiner.rb
@@ -2,7 +2,7 @@ require 'holidays'
 
 class BusinessCalendar::HolidayDeterminer
   DEFAULT_TIME_TO_LIVE = 24 * 60 * 60
-  attr_reader :regions, :holiday_names, :additions, :removals, :additions_only
+  attr_reader :regions, :holiday_names, :additions_only
 
   def initialize(regions, holiday_names, opts = {})
     ttl = opts[:ttl]
@@ -27,6 +27,14 @@ class BusinessCalendar::HolidayDeterminer
     end
   end
 
+  def additions
+    @additions_cache ||= @additions.is_a?(Proc) ? @additions.call : @additions
+  end
+
+  def removals
+    @removals_cache ||= @removals.is_a?(Proc) ? @removals.call : @removals
+  end
+
   private
 
   def should_clear_cache?
@@ -39,13 +47,5 @@ class BusinessCalendar::HolidayDeterminer
     @last_cleared = Time.now
     @additions_cache = nil
     @removals_cache = nil
-  end
-
-  def additions
-    @additions_cache ||= @additions.is_a?(Proc) ? @additions.call : @additions
-  end
-
-  def removals
-    @removals_cache ||= @removals.is_a?(Proc) ? @removals.call : @removals
   end
 end

--- a/spec/business_calendar/holiday_determiner_spec.rb
+++ b/spec/business_calendar/holiday_determiner_spec.rb
@@ -47,5 +47,9 @@ describe BusinessCalendar::HolidayDeterminer do
     it "correctly determines false for dates not in additions, nor exceptions" do
       expect(subject.call('2101-07-04'.to_date)).to be_falsy
     end
+
+    it "lists out the additions" do
+      expect(subject.additions).to include('2101-07-05'.to_date)
+    end
   end
 end


### PR DESCRIPTION
If  `additions` and `removals` are going to be methods, they should not be private.